### PR TITLE
add delivery class

### DIFF
--- a/lib/onesignal/delivery.rb
+++ b/lib/onesignal/delivery.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module OneSignal
+  class Delivery
+    attr_reader :send_after, :delayed_option, :delivery_time_of_day, :ttl, :priority
+
+    def initialize send_after: nil, delayed_option: nil, delivery_time_of_day: nil, ttl: nil, priority: nil
+      @send_after = send_after
+      @delayed_option = delayed_option
+      @delivery_time_of_day = delivery_time_of_day
+      @ttl = ttl
+      @priority = priority
+    end
+
+    def as_json options = nil
+      {
+        'send_after' => @send_after,
+        'delayed_option' => @delayed_option,
+        'delivery_time_of_day' => @delivery_time_of_day,
+        'ttl' => @ttl,
+        'priority' => @priority
+      }
+    end
+  end
+end

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,7 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :send_after, :delivery, :attachments, :sounds
+                :included_targets, :delivery, :attachments, :sounds
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -19,8 +19,7 @@ module OneSignal
       @included_segments = params[:included_segments]
       @excluded_segments = params[:excluded_segments]
       @included_targets  = params[:included_targets]
-      @send_after        = params[:send_after].to_s
-      @delivery        = params[:delivery]
+      @delivery          = params[:delivery]
       @attachments       = params[:attachments]
       @filters           = params[:filters]
       @sounds            = params[:sounds]

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,7 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :send_after, :attachments, :sounds
+                :included_targets, :send_after, :delivery, :attachments, :sounds
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -20,6 +20,7 @@ module OneSignal
       @excluded_segments = params[:excluded_segments]
       @included_targets  = params[:included_targets]
       @send_after        = params[:send_after].to_s
+      @delivery        = params[:delivery]
       @attachments       = params[:attachments]
       @filters           = params[:filters]
       @sounds            = params[:sounds]
@@ -27,9 +28,10 @@ module OneSignal
 
     def as_json options = {}
       super(options)
-        .except('attachments', 'sounds', 'included_targets')
+        .except('attachments', 'sounds', 'included_targets', 'delivery')
         .merge(@attachments&.as_json(options) || {})
         .merge(@sounds&.as_json(options) || {})
+        .merge(@delivery&.as_json(options) || {})
         .merge(@included_targets&.as_json(options) || {})
         .select { |_k, v| v.present? }
     end

--- a/spec/factories/delivery.rb
+++ b/spec/factories/delivery.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :delivery, class: OneSignal::Delivery do
+    send_after { 'Thu Sep 24 2015 14:00:00 GMT-0700 (PDT)' }
+    delayed_option { 'timezone' }
+    delivery_time_of_day { '21:45' }
+    ttl { 259200 }
+    priority { 10 }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
     attachments { build :attachments }
     included_segments { [build(:segment), build(:segment)] }
     excluded_segments { [build(:segment), build(:segment)] }
-    send_after { Time.now }
 
     initialize_with do
       new(attributes)

--- a/spec/onesignal/notification_spec.rb
+++ b/spec/onesignal/notification_spec.rb
@@ -25,6 +25,7 @@ describe Notification do
        Filter.country.equals('IT')]
     end
     let(:sounds) { build :sounds }
+    let(:delivery) { build :delivery }
     let(:targets) { IncludedTargets.new include_email_tokens: 'test', include_external_user_ids: 'test' }
 
     subject do
@@ -33,7 +34,7 @@ describe Notification do
             headings: headings,
             included_segments: segments,
             excluded_segments: segments,
-            send_after: time,
+            delivery: delivery,
             filters: filters,
             sounds: sounds,
             included_targets: targets
@@ -43,7 +44,12 @@ describe Notification do
       expect(subject.as_json).to eq(
         'contents' => contents.as_json,
         'headings' => headings.as_json,
-        'send_after' => time.to_s,
+        'send_after' => delivery.send_after.as_json,
+        'delayed_option' => delivery.delayed_option.as_json,
+        'delivery_time_of_day' => delivery.delivery_time_of_day.as_json,
+        'ttl' => delivery.ttl.as_json,
+        'ttl' => delivery.ttl.as_json,
+        'priority' => delivery.priority.as_json,
         'included_segments' => segments.as_json,
         'excluded_segments' => segments.as_json,
         'data' => subject.attachments.data.as_json,

--- a/spec/onesignal/notification_spec.rb
+++ b/spec/onesignal/notification_spec.rb
@@ -48,7 +48,6 @@ describe Notification do
         'delayed_option' => delivery.delayed_option.as_json,
         'delivery_time_of_day' => delivery.delivery_time_of_day.as_json,
         'ttl' => delivery.ttl.as_json,
-        'ttl' => delivery.ttl.as_json,
         'priority' => delivery.priority.as_json,
         'included_segments' => segments.as_json,
         'excluded_segments' => segments.as_json,


### PR DESCRIPTION
Added `Delivery` class based on https://documentation.onesignal.com/reference#section-delivery.

## Usage

```
notification = OneSignal::Notification.new(
  {
    headings: OneSignal::Notification::Headings.new(en: 'heading'),
    contents: OneSignal::Notification::Contents.new(en: 'content'),
    included_targets: OneSignal::IncludedTargets.new(include_player_ids: ['xxx']),
    delivery: OneSignal::Delivery.new(priority: 10)
  }
)
OneSignal.send_notification(notification)
```