### PR TITLE
バッジクラスの定数宣言方法の修正

### DIFF
--- a/lib/onesignal/badge.rb
+++ b/lib/onesignal/badge.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module OneSignal
-  module IOSBadgeType
-    NONE = 'None'
-    SET_TO = 'SetTo'
-    INCREASE = 'Increase'
-  end
-
   class Badge
+    class IOSBadgeType
+      NONE = 'None'
+      SET_TO = 'SetTo'
+      INCREASE = 'Increase'
+    end
+
     attr_reader :ios_badgeType, :ios_badgeCount
 
     def initialize ios_badgeType: nil, ios_badgeCount: nil


### PR DESCRIPTION
利用する側で
```
Caused by NameError: uninitialized constant
```
がでてしまったので定数定義の方法を変更