### PR TITLE
タイムアウトの値を設定出来るようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ OneSignal.configure do |config|
   config.api_url = 'http://my_api_url'
   config.active = false
   config.logger = Logger.new # Any Logger compliant implementation
+  config.open_timeout = 1
+  config.read_timeout = 1
 end
 ```
 ## Usage

--- a/lib/onesignal/client.rb
+++ b/lib/onesignal/client.rb
@@ -6,7 +6,7 @@ module OneSignal
   class Client
     class ApiError < RuntimeError; end
 
-    def initialize app_id, api_key, api_url
+    def initialize app_id, api_key, api_url, open_timeout, read_timeout
       @app_id = app_id
       @api_key = api_key
       @api_url = api_url
@@ -16,6 +16,8 @@ module OneSignal
         #   logger.filter(/(Basic )(\w+)/, '\1[REMOVED]')
         # end
         faraday.adapter Faraday.default_adapter
+        faraday.options[:open_timeout] = open_timeout
+        faraday.options[:timeout] = read_timeout
       end
     end
 

--- a/lib/onesignal/commands/base_command.rb
+++ b/lib/onesignal/commands/base_command.rb
@@ -12,7 +12,13 @@ module OneSignal
       end
 
       def client
-        @client ||= OneSignal::Client.new(config.app_id, config.api_key, config.api_url)
+        @client ||= OneSignal::Client.new(
+          config.app_id,
+          config.api_key,
+          config.api_url,
+          config.open_timeout,
+          config.read_timeout
+        )
       end
 
       def config

--- a/lib/onesignal/configuration.rb
+++ b/lib/onesignal/configuration.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module OneSignal
   class Configuration
-    attr_accessor :app_id, :api_key, :api_url, :active, :logger
+    attr_accessor :app_id, :api_key, :api_url, :active, :logger, :open_timeout, :read_timeout
 
     def initialize
       @app_id = ENV['ONESIGNAL_APP_ID']
@@ -14,6 +14,8 @@ module OneSignal
       @logger = Logger.new(STDOUT).tap do |logger|
         logger.level = Logger::INFO
       end
+      @open_timeout = 60
+      @read_timeout = 60
     end
   end
 end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -5,7 +5,9 @@ FactoryBot.define do
     app_id { 'app_id' }
     api_key { 'api_key' }
     api_url { 'http://api_url' }
+    open_timeout { 60 }
+    read_timeout { 60 }
 
-    initialize_with { new(app_id, api_key, api_url) }
+    initialize_with { new(app_id, api_key, api_url, open_timeout, read_timeout) }
   end
 end

--- a/spec/onesignal/notification/contents_spec.rb
+++ b/spec/onesignal/notification/contents_spec.rb
@@ -6,7 +6,7 @@ include OneSignal
 
 describe Notification::Contents do
   it 'requires at least an english content' do
-    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: en'
+    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: :en'
   end
 
   it 'creates a new Content with only english' do

--- a/spec/onesignal/notification/headings_spec.rb
+++ b/spec/onesignal/notification/headings_spec.rb
@@ -6,7 +6,7 @@ include OneSignal
 
 describe Notification::Headings do
   it 'requires at least an english content' do
-    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: en'
+    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: :en'
   end
 
   it 'creates a new Content with only english' do

--- a/spec/onesignal/segment_spec.rb
+++ b/spec/onesignal/segment_spec.rb
@@ -5,7 +5,7 @@ include OneSignal
 
 describe Segment do
   it 'requires a name' do
-    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: name'
+    expect { described_class.new }.to raise_error ArgumentError, 'missing keyword: :name'
   end
 
   context 'json' do


### PR DESCRIPTION
issue: https://github.com/medpeer-dev/kakari-issue/issues/1437

---

OneSignal障害発生時に備えてタイムアウトの値を調整したい

OneSignalが利用しているFaraday(の中のNet/HTTP)のデフォルトはopen_timeout, read_timeout共に60秒 (https://docs.ruby-lang.org/ja/latest/class/Net=3a=3aHTTP.html#I_OPEN_TIMEOUT 辺り参照)

程々に互換性を保つ為に本Gemのデフォルトは現行と同じ60秒としておく。
kakariは1秒くらいにしたいけど、5秒とか超えるケースがそこそこある (要検討