### PR TITLE
Appearances::Additionalsのandroid_channel_idをOneSignalに指定できるようにする

### DIFF
--- a/lib/onesignal/appearances.rb
+++ b/lib/onesignal/appearances.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# https://documentation.onesignal.com/reference#section-appearance
+module OneSignal
+  module Appearances
+    require 'onesignal/appearances/autoloader'
+  end
+end

--- a/lib/onesignal/appearances/additionals.rb
+++ b/lib/onesignal/appearances/additionals.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module OneSignal
+  module Appearances
+    class Additionals
+      attr_reader :android_channel_id
+
+      def initialize params
+        @android_channel_id = params[:android_channel_id]
+      end
+
+      def as_json options = nil
+        {
+          'android_channel_id' => android_channel_id
+        }
+      end
+    end
+  end
+end

--- a/lib/onesignal/appearances/additionals.rb
+++ b/lib/onesignal/appearances/additionals.rb
@@ -5,8 +5,8 @@ module OneSignal
     class Additionals
       attr_reader :android_channel_id
 
-      def initialize params
-        @android_channel_id = params[:android_channel_id]
+      def initialize android_channel_id: nil
+        @android_channel_id = android_channel_id
       end
 
       def as_json options = nil

--- a/lib/onesignal/appearances/autoloader.rb
+++ b/lib/onesignal/appearances/autoloader.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Dir["#{File.expand_path(__dir__)}/*.rb"].each do |file|
+  filename  = File.basename file
+  classname = filename.split('.rb').first.camelize
+  OneSignal::Appearances.autoload classname, File.expand_path("../#{filename}", __FILE__)
+end

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,8 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :delivery, :attachments, :sounds, :grouping, :badge
+                :included_targets, :delivery, :attachments, :sounds, :grouping, :badge,
+                :appearance_additionals
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -25,17 +26,22 @@ module OneSignal
       @sounds            = params[:sounds]
       @grouping          = params[:grouping]
       @badge             = params[:badge]
+      @appearance_additionals = params[:appearance_additionals]
     end
 
     def as_json options = {}
       super(options)
-        .except('attachments', 'sounds', 'included_targets', 'delivery', 'grouping', 'badge')
+        .except(
+          'attachments', 'sounds', 'included_targets', 'delivery', 'grouping', 'badge',
+          'appearance_additionals'
+        )
         .merge(@attachments&.as_json(options) || {})
         .merge(@sounds&.as_json(options) || {})
         .merge(@delivery&.as_json(options) || {})
         .merge(@grouping&.as_json(options) || {})
         .merge(@badge&.as_json(options) || {})
         .merge(@included_targets&.as_json(options) || {})
+        .merge(@appearance_additionals&.as_json(options) || {})
         .select { |_k, v| v.present? }
     end
   end

--- a/spec/factories/appearances/additionals.rb
+++ b/spec/factories/appearances/additionals.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :appearance_additionals, class: OneSignal::Appearances::Additionals do
+    android_channel_id { 'android_channel_id' }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/onesignal/notification_spec.rb
+++ b/spec/onesignal/notification_spec.rb
@@ -28,6 +28,7 @@ describe Notification do
     let(:delivery) { build :delivery }
     let(:grouping) { build :grouping }
     let(:badge) { build :badge }
+    let(:appearance_additionals) { build :appearance_additionals }
     let(:targets) { IncludedTargets.new include_email_tokens: 'test', include_external_user_ids: 'test' }
 
     subject do
@@ -41,6 +42,7 @@ describe Notification do
             badge: badge,
             filters: filters,
             sounds: sounds,
+            appearance_additionals: appearance_additionals,
             included_targets: targets
     end
 
@@ -71,7 +73,8 @@ describe Notification do
         'adm_sound'     => sounds.amazon.as_json,
         'wp_wns_sound'  => sounds.windows.as_json,
         'include_email_tokens' => targets.include_email_tokens,
-        'include_external_user_ids' => targets.include_external_user_ids
+        'include_external_user_ids' => targets.include_external_user_ids,
+        'android_channel_id' => appearance_additionals.android_channel_id
       )
     end
   end


### PR DESCRIPTION
https://github.com/medpeer-dev/kakari-issue/issues/1286#issuecomment-751679487 の対応
Androidにプッシュ通知を送信した際に、画面表示（ヘッドアップ）されるための対応です。

OneSignalドキュメント: https://documentation.onesignal.com/reference/create-notification#appearance